### PR TITLE
added options to 1) get xml document namespaces recursively and 2) remove namespaces from resulting array

### DIFF
--- a/xml2json.php
+++ b/xml2json.php
@@ -18,17 +18,18 @@
 
 function xmlToArray($xml, $options = array()) {
     $defaults = array(
-        'namespaceSeparator' => ':',//you may want this to be something other than a colon
-        'attributePrefix' => '@',   //to distinguish between attributes and nodes with the same name
-        'alwaysArray' => array(),   //array of xml tag names which should always become arrays
-        'autoArray' => true,        //only create arrays for tags which appear more than once
-        'textContent' => '$',       //key used for the text content of elements
-        'autoText' => true,         //skip textContent key if node has no attributes or child nodes
-        'keySearch' => false,       //optional search and replace on tag and attribute names
-        'keyReplace' => false       //replace values for above search values (as passed to str_replace())
+	    'namespaceRecursive' => false,  //setting to true will get xml doc namespaces recursively
+        'namespaceSeparator' => ':',    //you may want this to be something other than a colon
+        'attributePrefix' => '@',       //to distinguish between attributes and nodes with the same name
+        'alwaysArray' => array(),       //array of xml tag names which should always become arrays
+        'autoArray' => true,            //only create arrays for tags which appear more than once
+        'textContent' => '$',           //key used for the text content of elements
+        'autoText' => true,             //skip textContent key if node has no attributes or child nodes
+        'keySearch' => false,           //optional search and replace on tag and attribute names
+        'keyReplace' => false           //replace values for above search values (as passed to str_replace())
     );
     $options = array_merge($defaults, $options);
-    $namespaces = $xml->getDocNamespaces();
+    $namespaces = $xml->getDocNamespaces($options['namespaceRecursive']);
     $namespaces[''] = null; //add base (empty) namespace
  
     //get attributes from all namespaces

--- a/xml2json.php
+++ b/xml2json.php
@@ -19,6 +19,7 @@
 function xmlToArray($xml, $options = array()) {
     $defaults = array(
 	    'namespaceRecursive' => false,  //setting to true will get xml doc namespaces recursively
+	    'removeNamespace' => false,     //set to true if you want to remove the namespace from resulting keys (recommend setting namespaceSeparator = '' when this is set to true)
         'namespaceSeparator' => ':',    //you may want this to be something other than a colon
         'attributePrefix' => '@',       //to distinguish between attributes and nodes with the same name
         'alwaysArray' => array(),       //array of xml tag names which should always become arrays
@@ -35,6 +36,7 @@ function xmlToArray($xml, $options = array()) {
     //get attributes from all namespaces
     $attributesArray = array();
     foreach ($namespaces as $prefix => $namespace) {
+        if ($options['removeNamespace']) $prefix = "";
         foreach ($xml->attributes($namespace) as $attributeName => $attribute) {
             //replace characters in attribute name
             if ($options['keySearch']) $attributeName =
@@ -49,6 +51,7 @@ function xmlToArray($xml, $options = array()) {
     //get child nodes from all namespaces
     $tagsArray = array();
     foreach ($namespaces as $prefix => $namespace) {
+        if ($options['removeNamespace']) $prefix = "";
         foreach ($xml->children($namespace) as $childXml) {
             //recurse into child nodes
             $childArray = xmlToArray($childXml, $options);


### PR DESCRIPTION
@tamlyn - first, thanks for creating this - has come in very handy.  
1.  I have ran into a few xml files that had namespaces that had to be found recursively - and added the option to switch  $recursive parameter of getDocNamespaces to TRUE when option is set.  by default, parameter is set to  FALSE so that the function continues to perform as originally published.
2.  I also just committed another change to add option to remove namespaces in resulting array. Sorry didn't split this up into another branch - as it it now is included in the same pull request.
